### PR TITLE
snap: Set necessary env for gtk themes, needed for the system theme.

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -72,6 +72,10 @@ apps:
       GTK_EXE_PREFIX: $SNAP/usr
       GIMP2_LOCALEDIR: $SNAP/usr/share/locale
       PYTHONPATH: $SNAP/usr/lib/python2.7:$SNAP/usr/lib/python2.7/site-packages:$PYTHONPATH
+      GTK_PATH: $SNAP/lib/gtk-2.0
+      GTK_DATA_PREFIX: $SNAP
+      XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
+
     slots:
     - dbus-glimpse
     plugs:


### PR DESCRIPTION
When the system theme is selected under preferences we should get the theme set on the host.  This fixes that.