### PR TITLE
Improve build scripts

### DIFF
--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+cwd=$(pwd)
+export INSTALL_PREFIX=${INSTALL_PREFIX:-/usr/local}
+export SRC_PREFIX=${SRC_PREFIX:-$cwd}
+export INSTALL_COMMAND=${INSTALL_COMMAND:-sudo make install}
+export PATH=$INSTALL_PREFIX/bin:$PATH
+export PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig:$INSTALL_PREFIX/lib/x86_64-linux-gnu/pkgconfig:$INSTALL_PREFIX/share/pkgconfig:$PKG_CONFIG_PATH
+export LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$INSTALL_PREFIX/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+
+if [ ! -e $INSTALL_PREFIX ]; then
+    mkdir -p $INSTALL_PREFIX
+fi
+
+echo "** Cloning submodules in $SRC_PREFIX..."
+cd $SRC_PREFIX
+git submodule init
+git submodule update
+
+echo "** Building BABL in $SRC_PREFIX..."
+cd $SRC_PREFIX/babl
+./autogen.sh --prefix=$INSTALL_PREFIX
+make
+$INSTALL_COMMAND
+
+echo "** Building mypaint-brushes in $SRC_PREFIX..."
+cd $SRC_PREFIX/mypaint-brushes
+./autogen.sh --prefix=$INSTALL_PREFIX
+./configure --prefix=$INSTALL_PREFIX
+make
+$INSTALL_COMMAND
+
+echo "** Building libmypaint in $SRC_PREFIX..."
+cd $SRC_PREFIX/libmypaint
+./autogen.sh --prefix=$INSTALL_PREFIX
+./configure --prefix=$INSTALL_PREFIX
+make
+$INSTALL_COMMAND
+
+echo "** Building GEGL in $SRC_PREFIX..."
+cd $SRC_PREFIX/gegl
+cp ../install-sh .
+./autogen.sh --prefix=$INSTALL_PREFIX
+make
+$INSTALL_COMMAND
+
+echo "** Building Glimpse in $SRC_PREFIX..."
+cd $SRC_PREFIX
+./autogen.sh --prefix=$INSTALL_PREFIX
+make
+$INSTALL_COMMAND

--- a/glimpse-vagrant.sh
+++ b/glimpse-vagrant.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export INSTALL_PREFIX=/vagrant/glimpse-prefix
 export SRC_PREFIX=/vagrant
@@ -10,37 +10,4 @@ export ACLOCAL_FLAGS="-I $INSTALL_PREFIX/share/aclocal $ACLOCAL_FLAGS"
 mkdir -p $INSTALL_PREFIX
 mkdir -p $INSTALL_PREFIX/share/aclocal
 
-echo "Cloning submodules in $SRC_PREFIX..."
-git submodule update --init
-
-echo "Building BABL in $SRC_PREFIX..."
-cd $SRC_PREFIX/babl
-./autogen.sh --prefix=$INSTALL_PREFIX
-make
-make install
-
-echo "Building mypaint-brushes in $SRC_PREFIX..."
-cd $SRC_PREFIX/mypaint-brushes
-./autogen.sh --prefix=$INSTALL_PREFIX
-./configure --prefix=$INSTALL_PREFIX
-make
-make install
-
-echo "Building libmypaint in $SRC_PREFIX..."
-cd $SRC_PREFIX/libmypaint
-./autogen.sh --prefix=$INSTALL_PREFIX
-./configure --prefix=$INSTALL_PREFIX
-make
-make install
-
-echo "Building GEGL in $SRC_PREFIX..."
-cd $SRC_PREFIX/gegl
-./autogen.sh --prefix=$INSTALL_PREFIX
-make
-make install
-
-echo "Building Glimpse in $SRC_PREFIX..."
-cd $SRC_PREFIX
-./autogen.sh --prefix=$INSTALL_PREFIX
-make
-make install
+. build-linux.sh


### PR DESCRIPTION
To greatly support many kinds of build scenarios while still being flexible, this
improves the situation by providing a central build script that can both global install
and subdirectory install for packages and things.

* Rejigger glimpse-vagrant.sh to use the new build-linux.sh script.
* build-linux.sh is highly parametric, so environment variables can override its behavior.

This could be hypothethetically modified to support other unices than Linux, there are only
a few parts that assume bash and linux. (particularly the library path but idk how that works on other
platforms).

I have tested it on global install (the default) and just installing into a subdirectory tree which makes 
a nice binary tarball which we could support easily as a distribution method because of this (or pack it into a Debian package or whatever).
