### PR TITLE
Changed hide docks shortcut from tab to F12

### DIFF
--- a/etc/menurc
+++ b/etc/menurc
@@ -28,3 +28,4 @@
 (gtk_accel_path "<Actions>/tools/tools-scale" "<Primary>t")
 (gtk_accel_path "<Actions>/image/image-merge-layers" "")
 (gtk_accel_path "<Actions>/tools/tools-eraser" "e")
+(gtk_accel_path "<Actions>/windows/windows-hide-docks" "F12")


### PR DESCRIPTION
Fixes #504 

Changes proposed in this pull request:
- Default keyboard shortcut to hide docks is now F12 instead of the tab key

The rationale behind the change is that users may press the tab key accidentally and not know how to bring their dock back. F12 was chosen because it matches Inkscape.

**Edit: ON HOLD**. Remapping this function works, but the Tab key still performs the same function regardless of whether F12 is mapped or not. We need to understand why the Tab key is treated differently, and also why users cannot already create their own keyboard shortcuts using the Tab key.